### PR TITLE
Repository ssh key setup

### DIFF
--- a/docs/ssh-key-setup.md
+++ b/docs/ssh-key-setup.md
@@ -1,0 +1,44 @@
+# Настройка SSH ключа для репозитория
+
+## Текущая настройка
+
+В файле `.git/config` настроено использование SSH ключа через `core.sshCommand`.
+
+## Вариант 1: Использование ключа напрямую (текущая настройка)
+
+Если ключ находится в стандартном месте `~/.ssh/id_rsa`, настройка уже применена.
+
+Если ключ имеет другое имя (например, `~/.ssh/github_key`), измените в `.git/config`:
+```
+sshCommand = ssh -i ~/.ssh/github_key -o IdentitiesOnly=yes
+```
+
+## Вариант 2: Использование SSH config
+
+Если ключ настроен в `~/.ssh/config` через хост, можно использовать:
+
+1. Создайте или отредактируйте `~/.ssh/config`:
+```
+Host github-vdn
+    HostName github.com
+    User git
+    IdentityFile ~/.ssh/your_key_name
+    IdentitiesOnly yes
+```
+
+2. Измените URL в `.git/config`:
+```
+[remote "origin"]
+    url = git@github-vdn:vaskes79/vdn.git
+```
+
+3. Удалите или закомментируйте `core.sshCommand` в `.git/config`, так как хост из config будет использоваться автоматически.
+
+## Проверка настройки
+
+Проверьте подключение:
+```bash
+git fetch origin
+```
+
+Если всё настроено правильно, команда выполнится без ошибок.


### PR DESCRIPTION
Configure the repository to use a specific SSH key for all Git operations and provide documentation for SSH key setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-06b0569b-4202-427e-95ba-0259d7baa0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-06b0569b-4202-427e-95ba-0259d7baa0c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

